### PR TITLE
German language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ This is the wrapper component that creates the vertical timeline.
 
 - Props
 
-| name       | Type   | Required | Values Allowed   | default values                                                                                                                                                        | Description                                                                  |
-| ---------- | ------ | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| theme      | object | false    | colors           | { yearColor: "#888888", lineColor: "#c5c5c5", dotColor: "#c5c5c5", borderDotColor: "#ffffff", titleColor: "#cccccc", subtitleColor: "#888888", textColor: "#cccccc" } | Set colors in all components                                                 |
-| lang       | node   | false    | `en` or `es`     | `en`                                                                                                                                                                  | Change the language `from` and `to` texts and change the format in the dates |
-| dateFormat | string | false    | `L`, `l` or `ll` | `L`                                                                                                                                                                   | Change the presentation format of dates                                      |
+| name       | Type   | Required | Values Allowed     | default values                                                                                                                                                        | Description                                                                  |
+| ---------- | ------ | -------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| theme      | object | false    | colors             | { yearColor: "#888888", lineColor: "#c5c5c5", dotColor: "#c5c5c5", borderDotColor: "#ffffff", titleColor: "#cccccc", subtitleColor: "#888888", textColor: "#cccccc" } | Set colors in all components                                                 |
+| lang       | node   | false    | `en`, `es` or `de` | `en`                                                                                                                                                                  | Change the language `from` and `to` texts and change the format in the dates |
+| dateFormat | string | false    | `L`, `l` or `ll`   | `L`                                                                                                                                                                   | Change the presentation format of dates                                      |
 
 `dateFormat`: Receive only one of three options. (The options are same the [moment.js](https://momentjs.com/) using).
 
-- The option `L` will return a date like `MM/DD/YYYY` (in english) or `DD/MM/YYYY` (in spanish).
-- The option `l` will return a date like `M/D/YYYY` (in english) or `D/M/YYYY` (in spanish).
-- The option `ll` will return a date like `MMM DD, YYYY` (in english) or `DD de MMM, YYYY` (in spanish).
+- The option `L` will return a date like `MM/DD/YYYY` (in English), `DD/MM/YYYY` (in Spanish) `DD.MM.YYYY` (in German).
+- The option `l` will return a date like `M/D/YYYY` (in English), `D/M/YYYY` (in Spanish) `D.M.YYYY` (in German).
+- The option `ll` will return a date like `MMM DD, YYYY` (in English), `DD de MMM, YYYY` (in Spanish) `DD. MMM YYYY` (in German).
 
 ### Container
 

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -35,7 +35,7 @@ Timeline.defaultProps = {
 
 Timeline.propTypes = {
 	theme: shape({}),
-	lang: oneOf(['es', 'en']),
+	lang: oneOf(['es', 'en', 'de']),
 	dateFormat: oneOf(['L', 'l', 'll']),
 	children: oneOfType([arrayOf(node), node]).isRequired,
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,6 +41,20 @@ export const monthArray = {
 		'Nov',
 		'Dec',
 	],
+	de: [
+		'Jan.',
+		'Feb.',
+		'März',
+		'Apr.',
+		'Mai.',
+		'Juni',
+		'Juli',
+		'Aug.',
+		'Sep.',
+		'Okt.',
+		'Nov.',
+		'Dez.',
+	],
 };
 
 export const mapText = {
@@ -51,5 +65,9 @@ export const mapText = {
 	es: {
 		from: 'Desde',
 		to: 'Hasta',
+	},
+	de: {
+		from: 'Von',
+		to: 'Bis',
 	},
 };

--- a/src/helpers/transform-date.helper.js
+++ b/src/helpers/transform-date.helper.js
@@ -16,20 +16,41 @@ export const transformDate = ({ date, lang, type }) => {
 				? `${month ? `${completeWith0(month)}/` : ''}${
 						day ? `${completeWith0(day)}/` : ''
 				  }${year}`
-				: `${day ? `${completeWith0(day)}/` : ''}${
+				: lang === 'es'
+				? `${day ? `${completeWith0(day)}/` : ''}${
 						month ? `${completeWith0(month)}/` : ''
-				  }${year}`;
+				  }${year}`
+				: /* lang === 'de' */
+				  `${
+						day
+							? `${completeWith0(day)}.${
+									month ? `${completeWith0(month)}.` : ''
+							  }${year}`
+							: `${month ? `${completeWith0(month)}/` : ''}${year}`
+				  }`;
 		case 'l':
 			return lang === 'en'
 				? `${month ? `${month}/` : ''}${day ? `${day}/` : ''}${year}`
-				: `${day ? `${day}/` : ''}${month ? `${month}/` : ''}${year}`;
+				: lang === 'es'
+				? `${day ? `${day}/` : ''}${month ? `${month}/` : ''}${year}`
+				: /* lang === 'de' */
+				  `${
+						day
+							? `${day}.${month ? `${month}.` : ''}${year}`
+							: `${month ? `${month}/` : ''}${year}`
+				  }`;
 		case 'll':
 			return lang === 'en'
 				? `${month ? `${monthArray[lang][month - 1]}` : ''}${
 						day ? ` ${completeWith0(day)}` : ''
 				  }${day || month ? ', ' : ''}${year}`
-				: `${day ? `${day} de ` : ''}${
+				: lang === 'es'
+				? `${day ? `${day} de ` : ''}${
 						month ? `${monthArray[lang][month - 1]}, ` : ''
+				  }${year}`
+				: /* lang === 'de' */
+				  `${day ? `${day}. ` : ''}${
+						month ? `${monthArray[lang][month - 1]} ` : ''
 				  }${year}`;
 	}
 };
@@ -44,5 +65,10 @@ export const mapDate = {
 		L: (date) => transformDate({ date, lang: 'es', type: 'L' }),
 		l: (date) => transformDate({ date, lang: 'es', type: 'l' }),
 		ll: (date) => transformDate({ date, lang: 'es', type: 'll' }),
+	},
+	de: {
+		L: (date) => transformDate({ date, lang: 'de', type: 'L' }),
+		l: (date) => transformDate({ date, lang: 'de', type: 'l' }),
+		ll: (date) => transformDate({ date, lang: 'de', type: 'll' }),
 	},
 };

--- a/src/helpers/transform-date.helper.js
+++ b/src/helpers/transform-date.helper.js
@@ -22,10 +22,8 @@ export const transformDate = ({ date, lang, type }) => {
 				  }${year}`
 				: /* lang === 'de' */
 				  `${
-						day
-							? `${completeWith0(day)}.${
-									month ? `${completeWith0(month)}.` : ''
-							  }${year}`
+						day && month
+							? `${completeWith0(day)}.${completeWith0(month)}.${year}`
 							: `${month ? `${completeWith0(month)}/` : ''}${year}`
 				  }`;
 		case 'l':
@@ -35,8 +33,8 @@ export const transformDate = ({ date, lang, type }) => {
 				? `${day ? `${day}/` : ''}${month ? `${month}/` : ''}${year}`
 				: /* lang === 'de' */
 				  `${
-						day
-							? `${day}.${month ? `${month}.` : ''}${year}`
+						day && month
+							? `${day}.${month}.${year}`
 							: `${month ? `${month}/` : ''}${year}`
 				  }`;
 		case 'll':

--- a/test/components/__snapshots__/container.spec.js.snap
+++ b/test/components/__snapshots__/container.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<Container /> should create Snapshot 1`] = `
 <section
-  className="sc-AxiKw eozVxv"
+  className="sc-dlfnbm cWAGMS"
 >
   <div>
     First child
   </div>
   <div
-    className="sc-AxhCb ccMvAG"
+    className="sc-hKgILt"
   >
     <div>
       Second child

--- a/test/components/__snapshots__/description.spec.js.snap
+++ b/test/components/__snapshots__/description.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Description /> should create Snapshot 1`] = `
 <li
-  className="sc-fzoLsD gWtHBF"
+  className="sc-jrAGrp erWYBT"
 >
   text
 </li>

--- a/test/components/__snapshots__/section.spec.js.snap
+++ b/test/components/__snapshots__/section.spec.js.snap
@@ -2,15 +2,15 @@
 
 exports[`<Section /> should create Snapshot 1`] = `
 <article
-  className="sc-AxheI kdvXAR"
+  className="sc-gKsewC eXtzIU"
 >
   <p
-    className="sc-Axmtr kHDhOq"
+    className="sc-iBPRYJ eQfaEM"
   >
     title
   </p>
   <ul
-    className="sc-AxmLO chzFoG"
+    className="sc-fubCfw eTAXIs"
   >
     <div>
       children

--- a/test/components/__snapshots__/timeline.spec.js.snap
+++ b/test/components/__snapshots__/timeline.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<Timeline /> should create Snapshot 1`] = `
 <div
-  className="sc-AxjAm bXdGBi"
+  className="sc-bdfBwQ iNuYTL"
 >
   <div
-    className="sc-AxirZ lhnuda"
+    className="sc-gsTCUz fONLjA"
   >
     <div>
       Child

--- a/test/components/__snapshots__/year-content.spec.js.snap
+++ b/test/components/__snapshots__/year-content.spec.js.snap
@@ -2,12 +2,12 @@
 
 exports[`<YearContent /> should create Snapshot 1`] = `
 <p
-  className="sc-AxhUy hwimqV"
+  className="sc-eCssSg eJxYfY"
   format="L"
   lang="en"
 >
   <span
-    className="sc-AxgMl jZSFGj"
+    className="sc-jSgupP hSlCmR"
   >
     From
   </span>

--- a/test/components/year-content.spec.js
+++ b/test/components/year-content.spec.js
@@ -42,7 +42,7 @@ describe('<YearContent />', () => {
 		expect(wrapper.find('span').text()).toEqual('From');
 
 		expect(wrapper.find('time')).toHaveLength(2);
-		expect(wrapper.find('time').text().includes('2020')).toBeTruthy();
+		expect(wrapper.find('time').text().includes('2021')).toBeTruthy();
 		expect(wrapper.find('time').text().includes('08/21/2019')).toBeTruthy();
 	});
 

--- a/test/helpers/transform-date.helper.spec.js
+++ b/test/helpers/transform-date.helper.spec.js
@@ -195,6 +195,93 @@ describe('Helpers', () => {
 				});
 			});
 		});
+
+		describe('[lang = de]', () => {
+			const lang = 'de';
+
+			describe('[type = L]', () => {
+				const type = 'L';
+
+				it('should transform date with a format like DD.MM.YYYY', () => {
+					const date = '2020/10/31';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('31.10.2020');
+				});
+
+				it('should transform date with a format like MM/YYYY', () => {
+					const date = '2020/10';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('10/2020');
+				});
+
+				it('should transform date with a format like YYYY', () => {
+					const date = '2020';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('2020');
+				});
+			});
+
+			describe('[type = l]', () => {
+				const type = 'l';
+
+				it('should transform date with a format like D.M.YYYY', () => {
+					const dateOne = '2020/09/09';
+					const dateTwo = '2020/12/31';
+
+					const result = transformDate({ date: dateOne, lang, type });
+					expect(result).toEqual('9.9.2020');
+
+					const resultTwo = transformDate({ date: dateTwo, lang, type });
+					expect(resultTwo).toEqual('31.12.2020');
+				});
+
+				it('should transform date with a format like M/YYYY', () => {
+					const dateOne = '2020/09';
+					const dateTwo = '2020/12';
+
+					const result = transformDate({ date: dateOne, lang, type });
+					expect(result).toEqual('9/2020');
+
+					const resultTwo = transformDate({ date: dateTwo, lang, type });
+					expect(resultTwo).toEqual('12/2020');
+				});
+
+				it('should transform date with a format like YYYY', () => {
+					const date = '2020';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('2020');
+				});
+			});
+
+			describe('[type = ll]', () => {
+				const type = 'll';
+
+				it('should transform date with a format like DD. MMM. YYYY', () => {
+					const date = '2020/08/20';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('20. Aug. 2020');
+				});
+
+				it('should transform date with a format like MMM. YYYY', () => {
+					const date = '2020/08';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('Aug. 2020');
+				});
+
+				it('should transform date with a format like YYYY', () => {
+					const date = '2020';
+
+					const result = transformDate({ date, lang, type });
+					expect(result).toEqual('2020');
+				});
+			});
+		});
 	});
 
 	describe('mapDate hashmap', () => {
@@ -244,6 +331,30 @@ describe('Helpers', () => {
 			const date = '2020/08/21';
 
 			expect(mapDate[lang][type](date)).toEqual('21 de Ago, 2020');
+		});
+
+		it('LANG=de - TYPE=L', () => {
+			const lang = 'de';
+			const type = 'L';
+			const date = '2020/08/21';
+
+			expect(mapDate[lang][type](date)).toEqual('21.08.2020');
+		});
+
+		it('LANG=de - TYPE=l', () => {
+			const lang = 'de';
+			const type = 'l';
+			const date = '2020/08/21';
+
+			expect(mapDate[lang][type](date)).toEqual('21.8.2020');
+		});
+
+		it('LANG=de - TYPE=ll', () => {
+			const lang = 'de';
+			const type = 'll';
+			const date = '2020/08/21';
+
+			expect(mapDate[lang][type](date)).toEqual('21. Aug. 2020');
 		});
 	});
 });


### PR DESCRIPTION
This adds the language option `de` with the following formats:
- `L`: `12.03.2021` (day month year) and `03/2021` (month year)
- `l`: `12.3.2021` (day month year) and `3/2021` (month year)
- `ll`: `12. März 2021` (day month year) and `März 2021` (month year)

Changes timeline text `From` to `Von` and `To` to `Bis`.