### PR TITLE
Add Turkish support

### DIFF
--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -35,7 +35,7 @@ Timeline.defaultProps = {
 
 Timeline.propTypes = {
 	theme: shape({}),
-	lang: oneOf(['es', 'en', 'de']),
+	lang: oneOf(['es', 'en', 'de', 'tr']),
 	dateFormat: oneOf(['L', 'l', 'll']),
 	children: oneOfType([arrayOf(node), node]).isRequired,
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -55,6 +55,20 @@ export const monthArray = {
 		'Nov.',
 		'Dez.',
 	],
+	tr: [
+		'Ocak',
+		'Şubat',
+		'Mart',
+		'Nisan',
+		'Mayıs',
+		'Haziran',
+		'Temmuz',
+		'Ağustos',
+		'Eylül',
+		'Ekim',
+		'Kasım',
+		'Aralık'
+	]
 };
 
 export const mapText = {
@@ -70,4 +84,9 @@ export const mapText = {
 		from: 'Von',
 		to: 'Bis',
 	},
+	tr: {
+		from: 'Başlangıç',
+		to: 'Bitiş'
+		
+	}
 };


### PR DESCRIPTION
Technically, mapText translation is not from and to. 'Başlangıç' and 'Bitiş' translates to 'Start' and 'Finish'.  I did it this way because in Turkish, those words are suffixes so,'From march to April' translates to 'Marttan nisana kadar' which cannot be propery used in the context of the timeline.