### PR TITLE
changed wrong closing tag from </div> to </a> in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ class Main extends Component {
   return (
    <Timeline lang="en" theme={customTheme} dateFormat="only-number" collapse withoutDay>
     <Events
-     title={<a href="#">What is lorem Ipsum?</div>}
+     title={<a href="#">What is lorem Ipsum?</a>}
      subtitle="It's a fake text"
      startDate="2020/12/02"
      defaultClosed


### PR DESCRIPTION
## 📚 Description

There is a wrong closing tag in the README.md on line 143 that i simply changed from </div> to </a> so it doesn't give an error anymore if you try to copy the example.
